### PR TITLE
Handle missing owner data in discrete synchronization

### DIFF
--- a/R/getNewDiscrete.R
+++ b/R/getNewDiscrete.R
@@ -341,14 +341,13 @@ getNewDiscrete <- function(
             sample$sub_location <- NULL
             names_samp <- names(sample)
           }
-          # Check that the sample data has the required columns at minimum: c("location_id", "media_id", "datetime", "collection_method", "sample_type", "owner", "import_source_id"). Note that import_source_id is only mandatory because this function pulls data in from a remote source
+          # Check that the sample data has the required columns at minimum: c("location_id", "media_id", "datetime", "collection_method", "sample_type", "import_source_id"). Note that import_source_id is only mandatory because this function pulls data in from a remote source
           mandatory_samp <- c(
             "location_id",
             "media_id",
             "datetime",
             "collection_method",
             "sample_type",
-            "owner",
             "import_source_id"
           )
           if (!all(c(mandatory_samp) %in% names_samp)) {
@@ -373,6 +372,19 @@ getNewDiscrete <- function(
           # Apply default owner/contributor if not provided
           if (!("owner" %in% names_samp) || is.na(sample$owner)) {
             sample$owner <- owner
+            names_samp <- names(sample)
+          }
+          if (is.null(sample$owner) || is.na(sample$owner)) {
+            warning(
+              "For sample_series_id ",
+              sid,
+              " element ",
+              j,
+              " (sample_datetime ",
+              sample$datetime,
+              ") the source function did not provide an owner and there is no default owner for the sample series. Skipping to next sample."
+            )
+            next
           }
           if (!("contributor" %in% names_samp) || is.na(sample$contributor)) {
             if (!is.na(contributor)) sample$contributor <- contributor

--- a/R/synchronize_discrete.R
+++ b/R/synchronize_discrete.R
@@ -823,14 +823,13 @@ synchronize_discrete <- function(
                 names_inRemote_samp <- names(inRemote_sample)
               }
 
-              # Check that the sample data has the required columns at minimum: c("location_id", "media_id", "datetime", "collection_method", "sample_type", "owner", "import_source_id"). Note that import_source_id is only mandatory because this function pulls data in from a remote source
+              # Check that the sample data has the required columns at minimum: c("location_id", "media_id", "datetime", "collection_method", "sample_type", "import_source_id"). Note that import_source_id is only mandatory because this function pulls data in from a remote source
               mandatory_samp <- c(
                 "location_id",
                 "media_id",
                 "datetime",
                 "collection_method",
                 "sample_type",
-                "owner",
                 "import_source_id"
               )
               if (!all(c(mandatory_samp) %in% names_inRemote_samp)) {
@@ -860,6 +859,19 @@ synchronize_discrete <- function(
                   is.na(inRemote_sample$owner)
               ) {
                 inRemote_sample$owner <- default_owner
+                names_inRemote_samp <- names(inRemote_sample)
+              }
+              if (is.null(inRemote_sample$owner) || is.na(inRemote_sample$owner)) {
+                warning(
+                  "For sample_series_id ",
+                  sid,
+                  ", returned sample ",
+                  j,
+                  " (sample_datetime ",
+                  inRemote_sample$datetime,
+                  ") the source function did not provide an owner and there is no default owner for the sample series. Skipping to next sample."
+                )
+                next
               }
               if (
                 !("contributor" %in% names_inRemote_samp) ||


### PR DESCRIPTION
## Summary
- relax the getNewDiscrete sample validation to accept missing owner fields when a default owner is available
- add safeguards so both getNewDiscrete and synchronize_discrete warn and skip samples lacking an owner after defaults are applied

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_69019347af3c832f86e94ac70a16a66a